### PR TITLE
adding support for missing-SOA testing

### DIFF
--- a/.github/workflows/refresh_nameservers.yml
+++ b/.github/workflows/refresh_nameservers.yml
@@ -1,0 +1,28 @@
+name: tests
+on:
+  schedule:
+    # At 12:55 every Saturday
+    - cron:  '55 12 * * 6'
+jobs:
+  refresh_nameservers:
+    runs-on: ubuntu-latest
+    needs: lint
+    # if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+      - name: Refresh nameservers.txt
+        run: poetry run python public_dns_servers/clean_nameservers.py
+      - name: git add nameservers.txt
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: "nameservers.txt"
+          default_author: github_actions
+          message: "refresh nameservers.txt"

--- a/.github/workflows/test_for_soa.yml
+++ b/.github/workflows/test_for_soa.yml
@@ -1,0 +1,29 @@
+name: Nameservers File Monitor and Test for Missing SOA
+
+on:
+  push:
+    paths:
+      - 'nameservers.txt'
+  workflow_dispatch:
+
+jobs:
+  refresh_nameservers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+      - name: Test validated nameserver for missing SOA tolerance
+        run: poetry run python public_dns_servers/validate_no_soa.py
+      - name: git add nameservers-no_soa_friendly.txt
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: "nameservers-no_soa_friendly.txt"
+          default_author: github_actions
+          message: "refresh nameservers-no_soa_friendly.txt"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,6 @@ name: tests
 on:
   push:
   pull_request:
-  schedule:
-    # At 12:55 every Saturday
-    - cron:  '55 12 * * 6'
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -23,25 +20,3 @@ jobs:
       - name: flake8
         run: |
           flake8 --select F,E722 --ignore F403,F405,F541
-  refresh_nameservers:
-    runs-on: ubuntu-latest
-    needs: lint
-    # if: github.event_name == 'schedule'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          pip install poetry
-          poetry install
-      - name: Refresh nameservers.txt
-        run: poetry run python public_dns_servers/clean_nameservers.py
-      - name: git add nameservers.txt
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: "nameservers.txt"
-          default_author: github_actions
-          message: "refresh nameservers.txt"

--- a/public_dns_servers/validate_no_soa.py
+++ b/public_dns_servers/validate_no_soa.py
@@ -1,0 +1,77 @@
+import sys
+import dns.resolver
+import dns.exception
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+max_workers = 5
+dns_timeout = 1
+nameservers_txt_file = (Path(__file__).parent.parent / "nameservers.txt").resolve()
+no_soa_valid_txt_file = (
+    Path(__file__).parent.parent / "nameservers-no_soa_friendly.txt"
+).resolve()
+test_domain = "hackplanet.earth"
+
+
+def errprint(*args, **kwargs):
+    print(*args, **kwargs, file=sys.stderr)
+
+
+def do_validate_no_soa_tolerance(nameserver):
+    resolver = dns.resolver.Resolver()
+    resolver.timeout = dns_timeout
+    resolver.lifetime = dns_timeout
+    resolver.nameservers = [nameserver]
+
+    try:
+        resolver.resolve(test_domain, "NS")
+        valid = True
+
+    except (
+        dns.resolver.NoNameservers,
+        dns.resolver.LifetimeTimeout,
+        dns.resolver.NoAnswer,
+        dns.resolver.NXDOMAIN,
+    ) as e:
+        errprint(f"Resolver {nameserver} failed check")
+        valid = False
+
+    return nameserver, valid
+
+
+def validate_no_soa_tolerance(nameservers):
+    errprint(
+        f"Checking {len(nameservers):,} public nameservers for tolerance of missing SOA record"
+    )
+
+    futures = []
+    valid_nameservers = set()
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for nameserver in nameservers:
+            futures.append(executor.submit(do_validate_no_soa_tolerance, nameserver))
+
+        for future in as_completed(futures):
+            nameserver, valid = future.result()
+            if valid:
+                errprint(f"Resolver {nameserver} passed check")
+                valid_nameservers.add(nameserver)
+            else:
+                errprint(f"Resolver {nameserver} failed check")
+
+    errprint(
+        f"Found {len(valid_nameservers):,}/{len(nameservers):,} nameservers that tolerate missing SOA record"
+    )
+    return valid_nameservers
+
+
+def main():
+    with open(nameservers_txt_file) as file:
+        nameservers = [line.rstrip() for line in file]
+    valid_resolvers = validate_no_soa_tolerance(nameservers)
+    with open(no_soa_valid_txt_file, "w") as f:
+        for v in valid_resolvers:
+            f.write(f"{v}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/public_dns_servers/validate_no_soa.py
+++ b/public_dns_servers/validate_no_soa.py
@@ -32,8 +32,7 @@ def do_validate_no_soa_tolerance(nameserver):
         dns.resolver.LifetimeTimeout,
         dns.resolver.NoAnswer,
         dns.resolver.NXDOMAIN,
-    ) as e:
-        errprint(f"Resolver {nameserver} failed check")
+    ):
         valid = False
 
     return nameserver, valid


### PR DESCRIPTION
Part of baddns functionality will include looking for dangling NS records. It turns out, only a small minority of public DNS servers will let you do this, as they will look for a valid SOA record and essentially error out if they don't see one. However, this is exactly the condition we are looking for with that particular mode.

This PR adds an additional script and action that will piggy-back off the existing one, to further test the "valid" nameservers for their tolerance of a lack of SOA record. Those that pass this further test will be written to an additional text file.