### PR TITLE
fix: stop ASN stats job from committing an empty file

### DIFF
--- a/.github/workflows/refresh-nameservers.yml
+++ b/.github/workflows/refresh-nameservers.yml
@@ -21,7 +21,8 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # ~80 min expected at max_workers=10; headroom for a slow week
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python

--- a/.github/workflows/whoami.yml
+++ b/.github/workflows/whoami.yml
@@ -45,7 +45,24 @@ jobs:
           pyasn_util_convert.py --single rib.*.bz2 asn.db
       - name: Publish stats
         run: |
+          # Without pipefail the pipeline reports tee's exit status, so a
+          # crashing whoami.py looked like success while tee truncated the
+          # output file to zero bytes -- and that empty file got committed.
+          set -o pipefail
           python3 public_dns_servers/whoami.py | tee nameservers_by_asn.json
+      - name: Sanity-check output before committing
+        run: |
+          python3 - <<'PY'
+          import json
+          import sys
+
+          with open("nameservers_by_asn.json") as f:
+              asns = json.load(f)
+          nameservers = sum(len(v) for v in asns.values())
+          if len(asns) < 100:
+              sys.exit(f"Refusing to commit: only {len(asns)} ASNs resolved")
+          print(f"{len(asns):,} ASNs covering {nameservers:,} nameservers")
+          PY
       - name: git add nameservers_by_asn.json
         uses: EndBug/add-and-commit@v10
         with:

--- a/public_dns_servers/clean_nameservers.py
+++ b/public_dns_servers/clean_nameservers.py
@@ -10,7 +10,7 @@ import dns.exception
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-max_workers = 50
+max_workers = 10
 dns_timeout = 1
 min_reliability = 0.99
 nameservers_url = "https://public-dns.info/nameserver/nameservers.json"

--- a/public_dns_servers/whoami.py
+++ b/public_dns_servers/whoami.py
@@ -36,6 +36,13 @@ def main():
                 except Exception as e:
                     print(f"Error getting subnet for {ip}: {str(e)}", file=sys.stderr)
                     continue
+                # lookup() returns (None, None) for addresses that aren't in the
+                # RIB rather than raising, so the except above never catches it.
+                # Letting None become a dict key makes the json.dumps() below
+                # blow up on sort_keys, which empties the output file.
+                if asn is None:
+                    print(f"No ASN found for {ip}", file=sys.stderr)
+                    continue
                 print(
                     f"Nameserver {nameserver} uses IP {ip} (subnet: {subnet}, ASN: {asn})",
                     file=sys.stderr,


### PR DESCRIPTION
## What happened

The first real run of the ASN stats workflow committed a **0-byte** `nameservers_by_asn.json` over master.

`pyasn`'s `lookup()` returns `(None, None)` for an address absent from the RIB instead of raising, so the surrounding `except/continue` never fired and `None` became a dict key alongside integer ASNs:

```
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

That throw happens inside the `finally` block, so nothing reached stdout. The workflow pipes through `tee`, and a bash pipeline reports the *last* command's status — `tee` exited 0, the step went green, and the truncated file was committed.

The run was otherwise healthy: **4,057 nameservers mapped to ASNs correctly**. It only failed at serialization.

## Worth knowing

`nameservers_by_asn.json` has **never** been valid JSON. All three commits that ever touched it:

```
aa4a5b3  2024-09-02       0b   NOT JSON
b6f09d7  2024-09-02  111436b   NOT JSON  (815 lines of "Error querying..." text)
0ebcc19  2026-07-27       0b   NOT JSON  (this crash)
```

The 2024 corruption was a separate bug — failed queries printed to stdout, so `tee` captured error text into the file. Fixed in `9edfd4b`, but the bad output was never regenerated because the workflow never ran again. So there's no good version to restore; the file has to be regenerated once this lands.

## Changes

- **`whoami.py`** — skip addresses with no ASN instead of keying the dict on `None`.
- **`whoami.yml`** — `set -o pipefail` so a crash fails the step; plus a check that the output parses as JSON and holds ≥100 ASNs before the commit step runs.
- **`max_workers` 50 → 10.**

## On the concurrency change

Three full sweeps in 90 minutes:

| run | valid | timeouts | wrong answer |
|---|---|---|---|
| 21:56 | 5,015 | 40,618 | 26 |
| 22:52 | **405** | **45,251** | 5 |

Effectively all timeouts — the resolvers were fine, the answers just weren't coming back inside 1s. 50 was too aggressive a burst; 10 keeps roughly double the original throughput. Runtime goes ~16 min → ~80 min, so the refresh job timeout moves to 180.

## Verification

- Reproduced the crash against the live ASN DB: `lookup("198.51.100.7")` → `(None, None)`, and the old code path throws the exact `TypeError` from the CI log. Fixed path serializes fine.
- Guard tested against every failure mode seen:

| input | exit | result |
|---|---|---|
| empty file (this crash) | 1 | `JSONDecodeError` |
| error-text file (2024 state) | 1 | `JSONDecodeError` |
| valid but degraded (3 ASNs) | 1 | `Refusing to commit: only 3 ASNs resolved` |
| healthy (1,200 ASNs) | 0 | passes |

- `black --check` (26.5.1, CI's version) and `flake8` clean; all workflow YAML parses.

## After merge

`whoami.yml` is currently **disabled** so it couldn't re-wipe the file. Re-enable it once this is in:

```
gh workflow enable whoami.yml
```

Then a refresh run will regenerate the ASN file properly for the first time.
